### PR TITLE
[DE-2366] fix decimal scale

### DIFF
--- a/integration_tests/models/dim_as_primitive.sql
+++ b/integration_tests/models/dim_as_primitive.sql
@@ -1,5 +1,6 @@
 select
     {{ dbt_variant_utils.as_primitive(ref('stg_as_primitive'), 'same_type') }} as cast_same_type,
     {{ dbt_variant_utils.as_primitive(ref('stg_as_primitive'), 'with_null') }} as cast_with_null,
-    {{ dbt_variant_utils.as_primitive(ref('stg_as_primitive'), 'different_types') }} as cast_different_types
+    {{ dbt_variant_utils.as_primitive(ref('stg_as_primitive'), 'different_types') }} as cast_different_types,
+    {{ dbt_variant_utils.as_primitive(ref('stg_as_primitive'), 'decimal_number') }} as cast_decimal_number
 from {{ ref('stg_as_primitive') }}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -59,3 +59,7 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: number
+      - name: name_with_space
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: varchar

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -14,6 +14,10 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: variant
+      - name: decimal_number
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: variant
   - name: dim_as_primitive
     columns:
       - name: cast_same_type
@@ -28,6 +32,10 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: boolean
+      - name: cast_decimal_number
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: number
   - name: stg_object_pivot
     columns:
       - name: parsed_input
@@ -47,3 +55,7 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: boolean
+      - name: thud
+        tests:
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: number

--- a/integration_tests/models/stg_as_primitive.sql
+++ b/integration_tests/models/stg_as_primitive.sql
@@ -1,14 +1,17 @@
 select
     1::variant as same_type,
     'foo'::variant as with_null,
-    true::variant as different_types
+    true::variant as different_types,
+    0.567453454::variant as decimal_number
 union all
 select
     2::variant as same_type,
     null::variant as with_null,
-    4::variant as different_types
+    4::variant as different_types,
+    1.05::variant as decimal_number
 union all
 select
     3::variant as same_type,
     'bar'::variant as with_null,
-    false::variant as different_types
+    false::variant as different_types,
+    0.4532::variant as decimal_number

--- a/integration_tests/seeds/input_object_pivot.csv
+++ b/integration_tests/seeds/input_object_pivot.csv
@@ -1,5 +1,5 @@
 idx,input
 1,{}
 2,"{""foo"": ""bar"", ""excluded_key"": ""somevalue""}"
-3,"{""foo"": ""baz"", ""qux"": true}"
-4,"{""foo"": 1, ""qux"": false}"
+3,"{""foo"": ""baz"", ""qux"": true, ""thud"": 0.3234}"
+4,"{""foo"": 1, ""qux"": false, ""thud"": 1.32}"

--- a/integration_tests/seeds/input_object_pivot.csv
+++ b/integration_tests/seeds/input_object_pivot.csv
@@ -2,4 +2,4 @@ idx,input
 1,{}
 2,"{""foo"": ""bar"", ""excluded_key"": ""somevalue""}"
 3,"{""foo"": ""baz"", ""qux"": true, ""thud"": 0.3234}"
-4,"{""foo"": 1, ""qux"": false, ""thud"": 1.32}"
+4,"{""foo"": 1, ""qux"": false, ""thud"": 1.32, ""name with.space"": ""a value""}"

--- a/integration_tests/seeds/output_object_pivot.csv
+++ b/integration_tests/seeds/output_object_pivot.csv
@@ -1,5 +1,5 @@
-idx,foo,qux,thud
-1,null,null,null
-2,bar,null,null
-3,baz,true,0.3234
-4,null,false,1.32
+idx,foo,qux,thud,name_with_space
+1,null,null,null,null
+2,bar,null,null,null
+3,baz,true,0.3234,null
+4,null,false,1.32,a value

--- a/integration_tests/seeds/output_object_pivot.csv
+++ b/integration_tests/seeds/output_object_pivot.csv
@@ -1,5 +1,5 @@
-idx,foo,qux
-1,null,null
-2,bar,null
-3,baz,true
-4,null,false
+idx,foo,qux,thud
+1,null,null,null
+2,bar,null,null
+3,baz,true,0.3234
+4,null,false,1.32

--- a/macros/as_primitive.sql
+++ b/macros/as_primitive.sql
@@ -1,15 +1,28 @@
-{% macro as_primitive(t, c) %}
-    {% set type_query = run_query('select typeof(' ~ c ~ ') as type from ' ~ t ~ ' where type is not null limit 1') %}
+{%- macro as_primitive(t, c) -%}
+    {% set query = "
+        select 
+            typeof(" ~ c ~ ") as type, 
+            ifnull(len(split(" ~ c ~ ", '.')[1]), 2) as precision 
+        from " ~ t ~ " 
+        where type is not null 
+        limit 1" %}
+    {%- set type_query = run_query(query) -%}
 
-    {% if execute %}
-    {% set type = type_query.columns[0][0] %}
-    {% else %}
-    {% set type = none %}
-    {% endif %}
+    {%- if execute -%}
+    {%- set type = type_query.columns[0][0] -%}
+    {%- set precision = type_query.columns[1][0] -%}
+    {%- else -%}
+    {%- set type = none -%}
+    {%- set precision = none -%}
+    {%- endif -%}
 
-    {% if type and type|lower not in ['null_value'] %}
-        as_{{ type|lower }}({{ c }})
-    {% else %}
+    {%- if type and type|lower not in ['null_value'] -%}
+        {%- if type|lower == 'decimal' %}
+            as_{{ type|lower }}({{ c }}, 38, {{ precision }})
+        {%- else %}
+            as_{{ type|lower }}({{ c }})
+        {%- endif -%}
+    {%- else %}
         null
-    {% endif %}
+    {%- endif -%}
 {% endmacro %}

--- a/macros/object_pivot.sql
+++ b/macros/object_pivot.sql
@@ -1,11 +1,13 @@
 {%- macro object_pivot(t, c, primitive=true, include_columns=[], exclude_keys=['null']) -%}
-    {%- set query = "select distinct regexp_replace(key, '[ .]', '_') from " ~ t ~ ", lateral flatten(" ~ c ~ ")" -%}
+    {%- set query = "select distinct key, regexp_replace(key, '[ .]', '_') as alias_key from " ~ t ~ ", lateral flatten(" ~ c ~ ")" -%}
     {%- set keys_query = run_query(query) -%}
     
     {%- if execute -%}
     {%- set keys = keys_query.columns[0].values() -%}
+    {%- set alias_keys = keys_query.columns[1].values() -%}
     {%- else -%}
     {%- set keys = [] -%}
+    {%- set alias_keys = [] -%}
     {%- endif -%}
 
     select
@@ -13,11 +15,12 @@
         {{ ic }},
     {%- endfor -%}
     {%- for k in keys -%}
+    {%- set alias_key = alias_keys[loop.index0] -%}
         {%- if k not in exclude_keys -%}
             {%- if primitive -%}
-                {{ dbt_variant_utils.as_primitive(t, "get(" ~ c ~ ", '" ~ k ~ "')") }} as {{ k }}
+                {{ dbt_variant_utils.as_primitive(t, "get(" ~ c ~ ", '" ~ k ~ "')") }} as {{ alias_key }}
             {%- else -%}
-                get({{ c }}, '{{ k }}') as {{ k }}
+                get({{ c }}, '{{ k }}') as {{ alias_key }}
             {%- endif -%}
             {%- if not loop.last -%},{%- endif -%}
         {%- endif -%}

--- a/macros/object_pivot.sql
+++ b/macros/object_pivot.sql
@@ -1,26 +1,26 @@
-{% macro object_pivot(t, c, primitive=true, include_columns=[], exclude_keys=['null']) %}
-    {% set query = "select distinct regexp_replace(key, '[ .]', '_') from " ~ t ~ ", lateral flatten(" ~ c ~ ")" %}
-    {% set keys_query = run_query(query) %}
+{%- macro object_pivot(t, c, primitive=true, include_columns=[], exclude_keys=['null']) -%}
+    {%- set query = "select distinct regexp_replace(key, '[ .]', '_') from " ~ t ~ ", lateral flatten(" ~ c ~ ")" -%}
+    {%- set keys_query = run_query(query) -%}
     
-    {% if execute %}
-    {% set keys = keys_query.columns[0].values() %}
-    {% else %}
-    {% set keys = [] %}
-    {% endif %}
+    {%- if execute -%}
+    {%- set keys = keys_query.columns[0].values() -%}
+    {%- else -%}
+    {%- set keys = [] -%}
+    {%- endif -%}
 
     select
-    {% for ic in include_columns %}
+    {%- for ic in include_columns %}
         {{ ic }},
-    {% endfor %}
-    {% for k in keys %}
-        {% if k not in exclude_keys %}
-            {% if primitive %}
+    {%- endfor -%}
+    {%- for k in keys -%}
+        {%- if k not in exclude_keys -%}
+            {%- if primitive -%}
                 {{ dbt_variant_utils.as_primitive(t, "get(" ~ c ~ ", '" ~ k ~ "')") }} as {{ k }}
-            {% else %}
+            {%- else -%}
                 get({{ c }}, '{{ k }}') as {{ k }}
-            {% endif %}
-            {% if not loop.last %},{% endif %}
-        {% endif %}
-    {% endfor %}
+            {%- endif -%}
+            {%- if not loop.last -%},{%- endif -%}
+        {%- endif -%}
+    {%- endfor %}
     from {{ t }}
 {% endmacro %}


### PR DESCRIPTION
This is to fix an issue where decimal numbers were getting rounded to the nearest whole number (i.e. scale was defaulting to 0). Now scale is set by the first not null value for columns of decimal type.